### PR TITLE
Change external_id to id

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ This example shows how to use the indexDocuments method:
     const contentSourceKey = '' // your content source key
     const documents = [
       {
-        external_id: 1234,
+        id: 1234,
         title: "5 Tips On Finding A Mentor",
         body: "The difference between a budding entrepreneur who merely shows promise and one who is already enjoying some success often comes down to mentoring.",
         url: "https://www.shopify.com/content/5-tips-on-finding-a-mentor"
       },
       {
-        external_id: 1235,
+        id: 1235,
         title: "How to Profit from Your Passions",
         body: "Want to know the secret to starting a successful business? Find a void and fill it.",
         url: "https://www.shopify.com/content/how-to-profit-from-your-passions"
@@ -63,9 +63,9 @@ This example shows how to use the indexDocuments method:
 ### Destroying Documents
 
     const contentSourceKey = '' // your content source key
-    const documentExternalIds = [1234, 1235]
+    const documentIds = [1234, 1235]
 
-    swiftype.destroyDocuments(contentSourceKey, documentExternalIds)
+    swiftype.destroyDocuments(contentSourceKey, documentIds)
     .then((destroyDocumentsResults) => {
       // handle destroy documents results
     })

--- a/fixtures/api.swiftype.com-443/14987978186998303
+++ b/fixtures/api.swiftype.com-443/14987978186998303
@@ -3,7 +3,7 @@ content-type: application/json
 host: api.swiftype.com
 authorization: Bearer mockAccessToken
 accept: application/json
-body: [{\"external_id\":1234,\"title\":\"5 Tips On Finding A Mentor\",\"body\":\"The difference between a budding entrepreneur who merely shows promise and one who is already enjoying some success often comes down to mentoring.\",\"url\":\"https://www.shopify.com/content/5-tips-on-finding-a-mentor\"},{\"external_id\":1235,\"title\":\"How to Profit from Your Passions\",\"body\":\"Want to know the secret to starting a successful business? Find a void and fill it.\",\"url\":\"https://www.shopify.com/content/how-to-profit-from-your-passions\"}]
+body: [{\"id\":1234,\"title\":\"5 Tips On Finding A Mentor\",\"body\":\"The difference between a budding entrepreneur who merely shows promise and one who is already enjoying some success often comes down to mentoring.\",\"url\":\"https://www.shopify.com/content/5-tips-on-finding-a-mentor\"},{\"id\":1235,\"title\":\"How to Profit from Your Passions\",\"body\":\"Want to know the secret to starting a successful business? Find a void and fill it.\",\"url\":\"https://www.shopify.com/content/how-to-profit-from-your-passions\"}]
 
 HTTP/1.1 202 Accepted
 date: Fri, 30 Jun 2017 04:43:38 GMT
@@ -21,4 +21,4 @@ x-request-id: 38d639d5-fb96-4d21-a2ea-94044ffa5012
 x-runtime: 0.092065
 x-rack-cache: invalidate, pass
 
-[{"id":null,"external_id":"1234","errors":[]},{"id":null,"external_id":"1235","errors":[]}]
+[{"id":null,"id":"1234","errors":[]},{"id":null,"id":"1235","errors":[]}]

--- a/fixtures/api.swiftype.com-443/149879818379960951
+++ b/fixtures/api.swiftype.com-443/149879818379960951
@@ -23,4 +23,4 @@ x-swiftype-datacenter: dal05
 x-swiftype-frontend-node: web01.dal05
 x-swiftype-edge-node: web01.dal05
 
-[{"external_id":1234,"success":true},{"external_id":1235,"success":true}]
+[{"id":1234,"success":true},{"id":1235,"success":true}]

--- a/lib/swiftypeEnterprise.js
+++ b/lib/swiftypeEnterprise.js
@@ -1,7 +1,7 @@
 const Client = require('./client')
 
 const REQUIRED_TOP_LEVEL_KEYS = Object.freeze([
-  'external_id',
+  'id',
   'url',
   'title',
   'body'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftype-enterprise-node",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Swiftype Enterprise Node.js client",
   "files": [
     "lib/"

--- a/test/test.js
+++ b/test/test.js
@@ -6,13 +6,13 @@ const mockAccessToken = 'mockAccessToken'
 const mockContentSourceKey = 'mockContentSourceKey'
 const mockDocuments = [
   {
-    external_id: 1234,
+    id: 1234,
     title: '5 Tips On Finding A Mentor',
     body: 'The difference between a budding entrepreneur who merely shows promise and one who is already enjoying some success often comes down to mentoring.',
     url: 'https://www.shopify.com/content/5-tips-on-finding-a-mentor'
   },
   {
-    external_id: 1235,
+    id: 1235,
     title: 'How to Profit from Your Passions',
     body: 'Want to know the secret to starting a successful business? Find a void and fill it.',
     url: 'https://www.shopify.com/content/how-to-profit-from-your-passions'
@@ -29,8 +29,8 @@ describe('SwiftypeEnterpriseClient', () => {
         .then(results => {
           assert.deepEqual(
             [
-              { id: null, external_id: '1234', errors: [] },
-              { id: null, external_id: '1235', errors: [] }
+              { id: null, id: '1234', errors: [] },
+              { id: null, id: '1235', errors: [] }
             ],
             results
           )
@@ -44,9 +44,9 @@ describe('SwiftypeEnterpriseClient', () => {
 
   describe('#destroyDocuments', () => {
     it('should destroy documents', (done) => {
-      swiftype.destroyDocuments(mockContentSourceKey, mockDocuments.map((doc) => doc.external_id))
+      swiftype.destroyDocuments(mockContentSourceKey, mockDocuments.map((doc) => doc.id))
       .then((documentDestroyResults) => {
-        assert.deepEqual([{ external_id: 1234, success: true }, { external_id: 1235, success: true }], documentDestroyResults)
+        assert.deepEqual([{ id: 1234, success: true }, { id: 1235, success: true }], documentDestroyResults)
         done()
       })
       .catch((error) => {


### PR DESCRIPTION
The documents API is changing to be just 'id' instead of 'external_id'.

These changes adhere to the new requirement.

Bumped to version 3.0.0 since this is a breaking change.