### PR TITLE
Updated base endpoints and versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Create a new instance of the Swiftype Enterprise Client with your access token:
     const accessToken = '' // your access token
     const swiftype = new SwiftypeEnterpriseClient(accessToken)
 
+### Change API endpoint
+
+```
+const swiftype = new SwiftypeEnterpriseClient(accessToken, 'https://your-server.example.com/api/v1/ent')
+```
+
 ### Indexing Documents
 
 This example shows how to use the indexDocuments method:

--- a/lib/swiftypeEnterprise.js
+++ b/lib/swiftypeEnterprise.js
@@ -15,7 +15,7 @@ const CORE_TOP_LEVEL_KEYS = Object.freeze(REQUIRED_TOP_LEVEL_KEYS + OPTIONAL_TOP
 
 class SwiftypeEnterpriseClient {
 
-  constructor(accessToken, baseUrl = 'https://api.swiftype.com/api/v1/ent') {
+    constructor(accessToken, baseUrl = 'http://localhost:3002/api/v1/ent') {
     this.client = new Client(accessToken, baseUrl)
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftype-enterprise-node",
-  "version": "2.0.0",
+  "version": "7.2.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftype-enterprise-node",
-  "version": "3.0.0",
+  "version": "7.2.0-beta.2",
   "description": "Swiftype Enterprise Node.js client",
   "files": [
     "lib/"

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ const mockDocuments = [
 ]
 
 describe('SwiftypeEnterpriseClient', () => {
-  const swiftype = new SwiftypeEnterpriseClient(mockAccessToken)
+  const swiftype = new SwiftypeEnterpriseClient(mockAccessToken, 'https://api.swiftype.com/api/v1/ent')
 
   describe('#indexDocuments', () => {
     it('should index documents', done => {


### PR DESCRIPTION
- Changed default endpoint to `localhost`.
- Documented how to change endpoint.
- Updated version to match enterprise search version, 7.2.0-beta.2.