### PR TITLE
Flexible Schema Support: Removed field validations

### DIFF
--- a/lib/swiftypeEnterprise.js
+++ b/lib/swiftypeEnterprise.js
@@ -1,34 +1,10 @@
 const Client = require('./client')
 
-const REQUIRED_TOP_LEVEL_KEYS = Object.freeze([
-  'id',
-  'url',
-  'title',
-  'body'
-])
-const OPTIONAL_TOP_LEVEL_KEYS = Object.freeze([
-  'created_at',
-  'updated_at',
-  'type'
-])
-const CORE_TOP_LEVEL_KEYS = Object.freeze(REQUIRED_TOP_LEVEL_KEYS + OPTIONAL_TOP_LEVEL_KEYS)
 
 class SwiftypeEnterpriseClient {
 
     constructor(accessToken, baseUrl = 'http://localhost:3002/api/v1/ent') {
     this.client = new Client(accessToken, baseUrl)
-  }
-
-  validateDocument(doc) {
-    const docKeys = Object.keys(doc)
-    const missingKeys = REQUIRED_TOP_LEVEL_KEYS.filter((key) => !docKeys.includes(key))
-    if (missingKeys.length > 0) {
-      throw new Error(`Missing required keys: ${missingKeys.join(',')}`)
-    }
-    const invalidKeys = docKeys.filter((key) => !CORE_TOP_LEVEL_KEYS.includes(key))
-    if (invalidKeys.length > 0) {
-      throw new Error(`Invalid keys: ${invalidKeys.join(',')}. Valid keys are: ${CORE_TOP_LEVEL_KEYS}.`)
-    }
   }
 
    /**
@@ -37,7 +13,6 @@ class SwiftypeEnterpriseClient {
    * each indexed document.
    */
   indexDocuments(contentSourceKey, documents) {
-    documents.forEach(this.validateDocument)
     return this.client.post(
       `/sources/${contentSourceKey}/documents/bulk_create`,
       documents


### PR DESCRIPTION
Enterprise Search is being updated to have flexible schema
support, so that any field will be allowed. Additionally, we don't
need to do field validations in this client as they are being validated
in the API itself.

Reference: https://swiftype.atlassian.net/browse/ENG-1675