### PR TITLE
Fixes after adding new endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ client
   })
 ```
 
-### Getting permissions list
+### Listing all permissions
 
 ```javascript
 const contentSourceKey = '' // your content source key
 const pageParams = { currentPage: 2, pageSize: 20 } // optional argument
 
 client
-  .getPermissions(contentSourceKey, pageParams)
+  .listAllPermissions(contentSourceKey, pageParams)
   .then(response => {
     // handle response
   })

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ client
 ```javascript
 const contentSourceKey = '' // your content source key
 const user = 'enterprise_search' // username
-const permissions = ['permission1', 'permission2'] // array of permissions to assign to the user
+const permissions = { permissions: ['permission1', 'permission2'] } // permissions to assign to the user
 
 client
   .updateUserPermissions(contentSourceKey, user, permissions)
@@ -152,7 +152,7 @@ client
 ```javascript
 const contentSourceKey = '' // your content source key
 const user = 'enterprise_search' // username
-const permissions = ['permission2'] // array of permissions to add to the user
+const permissions = { permissions: ['permission2'] } // permissions to add to the user
 
 client
   .addUserPermissions(contentSourceKey, user, permissions)
@@ -169,7 +169,7 @@ client
 ```javascript
 const contentSourceKey = '' // your content source key
 const user = 'enterprise_search' // username
-const permissions = ['permission2'] // array of permissions to remove from the user
+const permissions = { permissions: ['permission2'] } //permissions to remove from the user
 
 client
   .removeUserPermissions(contentSourceKey, user, permissions)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ client
 
 ```javascript
 const contentSourceKey = '' // your content source key
-const user = 'elastic'
+const user = 'enterprise_search' // username
 
 client
   .getUserPermissions(contentSourceKey, user)

--- a/lib/enterpriseSearch.js
+++ b/lib/enterpriseSearch.js
@@ -32,7 +32,7 @@ class EnterpriseSearchClient {
   /**
    * Lists users permissions for a content source identified by the contentSourceKey.
    */
-  getPermissions(contentSourceKey, pageParams) {
+  listAllPermissions(contentSourceKey, pageParams) {
     const pageParamsForQuery = pageParams
       ? {
           ...(pageParams.currentPage && {

--- a/lib/enterpriseSearch.js
+++ b/lib/enterpriseSearch.js
@@ -55,21 +55,21 @@ class EnterpriseSearchClient {
   updateUserPermissions(contentSourceKey, user, permissions) {
     return this.client.post(
       `/sources/${contentSourceKey}/permissions/${user}`,
-      { permissions }
+      permissions
     )
   }
 
   addUserPermissions(contentSourceKey, user, permissions) {
     return this.client.post(
       `/sources/${contentSourceKey}/permissions/${user}/add`,
-      { permissions }
+      permissions
     )
   }
 
   removeUserPermissions(contentSourceKey, user, permissions) {
     return this.client.post(
       `/sources/${contentSourceKey}/permissions/${user}/remove`,
-      { permissions }
+      permissions
     )
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -141,7 +141,7 @@ describe('EnterpriseSearchClient', () => {
 
   context('#permissions', () => {
     it('should list permissions', async () => {
-      const results = await client.getPermissions(mockContentSourceKey)
+      const results = await client.listAllPermissions(mockContentSourceKey)
       assert.deepEqual(results, {
         meta: {
           page: { current: 1, total_pages: 1, total_results: 2, size: 25 }
@@ -154,7 +154,7 @@ describe('EnterpriseSearchClient', () => {
     })
 
     it('should pass page size', async () => {
-      const results = await client.getPermissions(mockContentSourceKey, {
+      const results = await client.listAllPermissions(mockContentSourceKey, {
         pageSize: 1
       })
       assert.deepEqual(results, {
@@ -166,7 +166,7 @@ describe('EnterpriseSearchClient', () => {
     })
 
     it('should pass current page', async () => {
-      const results = await client.getPermissions(mockContentSourceKey, {
+      const results = await client.listAllPermissions(mockContentSourceKey, {
         currentPage: 2
       })
       assert.deepEqual(results, {
@@ -178,7 +178,7 @@ describe('EnterpriseSearchClient', () => {
     })
 
     it('should pass page size and current page', async () => {
-      const results = await client.getPermissions(mockContentSourceKey, {
+      const results = await client.listAllPermissions(mockContentSourceKey, {
         pageSize: 1,
         currentPage: 2
       })

--- a/test/test.js
+++ b/test/test.js
@@ -206,7 +206,7 @@ describe('EnterpriseSearchClient', () => {
       const results = await client.updateUserPermissions(
         mockContentSourceKey,
         'enterprise_search',
-        ['permission1']
+        { permissions: ['permission1'] }
       )
       assert.deepEqual(results, {
         user: 'enterprise_search',
@@ -220,7 +220,7 @@ describe('EnterpriseSearchClient', () => {
       const results = await client.addUserPermissions(
         mockContentSourceKey,
         'enterprise_search',
-        ['permission2']
+        { permissions: ['permission2'] }
       )
       assert.deepEqual(results, {
         user: 'enterprise_search',
@@ -234,7 +234,7 @@ describe('EnterpriseSearchClient', () => {
       const results = await client.removeUserPermissions(
         mockContentSourceKey,
         'enterprise_search',
-        ['permission2']
+        { permissions: ['permission2'] }
       )
       assert.deepEqual(results, {
         user: 'enterprise_search',

--- a/test/test.js
+++ b/test/test.js
@@ -46,7 +46,7 @@ nock('https://api.swiftype.com/api/v1/ent', {
   .reply(200, {
     meta: { page: { current: 1, total_pages: 1, total_results: 2, size: 25 } },
     results: [
-      { user: 'elastic', permissions: [] },
+      { user: 'enterprise_search2', permissions: [] },
       { user: 'enterprise_search', permissions: [] }
     ]
   })
@@ -54,7 +54,7 @@ nock('https://api.swiftype.com/api/v1/ent', {
   .query({ page: { size: 1 } })
   .reply(200, {
     meta: { page: { current: 1, total_pages: 2, total_results: 2, size: 1 } },
-    results: [{ user: 'elastic', permissions: [] }]
+    results: [{ user: 'enterprise_search2', permissions: [] }]
   })
   .get(`/sources/${mockContentSourceKey}/permissions`)
   .query({ page: { current: 2 } })
@@ -68,8 +68,8 @@ nock('https://api.swiftype.com/api/v1/ent', {
     meta: { page: { current: 2, total_pages: 2, total_results: 2, size: 1 } },
     results: [{ user: 'enterprise_search', permissions: [] }]
   })
-  .get(`/sources/${mockContentSourceKey}/permissions/elastic`)
-  .reply(200, { user: 'elastic', permissions: [] })
+  .get(`/sources/${mockContentSourceKey}/permissions/enterprise_search`)
+  .reply(200, { user: 'enterprise_search', permissions: [] })
   .post(`/sources/${mockContentSourceKey}/permissions/enterprise_search`, {
     permissions: ['permission1']
   })
@@ -147,7 +147,7 @@ describe('EnterpriseSearchClient', () => {
           page: { current: 1, total_pages: 1, total_results: 2, size: 25 }
         },
         results: [
-          { user: 'elastic', permissions: [] },
+          { user: 'enterprise_search2', permissions: [] },
           { user: 'enterprise_search', permissions: [] }
         ]
       })
@@ -161,7 +161,7 @@ describe('EnterpriseSearchClient', () => {
         meta: {
           page: { current: 1, total_pages: 2, total_results: 2, size: 1 }
         },
-        results: [{ user: 'elastic', permissions: [] }]
+        results: [{ user: 'enterprise_search2', permissions: [] }]
       })
     })
 
@@ -195,9 +195,9 @@ describe('EnterpriseSearchClient', () => {
     it('should get user permissions', async () => {
       const results = await client.getUserPermissions(
         mockContentSourceKey,
-        'elastic'
+        'enterprise_search'
       )
-      assert.deepEqual(results, { user: 'elastic', permissions: [] })
+      assert.deepEqual(results, { user: 'enterprise_search', permissions: [] })
     })
   })
 


### PR DESCRIPTION
1) Unwrap permissions array (discussed in the [similar PR for ruby](https://github.com/elastic/enterprise-search-ruby/pull/15#discussion_r332668931))
2) Rename getPermissions -> listAllPermissions (according to new OpenAPI spec)
3) Don't use elastic as username in tests and readme (We're not sure how this user is going to be treated in Enterprise Search, so it's better not to give wrong examples)